### PR TITLE
Host networking enabled in docker compose.

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
-NEO4J_URI=bolt://neo4j:7687
+NEO4J_URI=bolt://localhost:7687
 NEO4J_USER=neo4j
 NEO4J_PASSWORD=password

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ It should start a streamlit app on port `8503`.
 ## Advanced settings
 - Modify the environment variables in the docker-compose.yml file to customize neo4j project settings.
 - To run Ollama, ensure it is installed and accessible from the Docker container. Update the environment variables in the docker-compose.yml file accordingly.
+- On MacOS Docker Desktop, goto Settings > Resources > Network and "Enable Host Networking".
 
 ## Resources
 - [Intro Blog](https://medium.com/@anunayaatipamula/building-a-memory-augmented-learning-companion-from-idea-to-implementation-49970ac6da16)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   neo4j:
     image: neo4j:latest # Or a specific version, e.g., neo4j:4.4
+    network_mode: "host"
     ports:
       - "7474:7474" # HTTP
       - "7687:7687" # Bolt
@@ -11,6 +12,7 @@ services:
 
   neuro-trail:
     build: . # Build from the Dockerfile in the current directory
+    network_mode: "host"
     depends_on:
       - neo4j
     ports:
@@ -23,3 +25,8 @@ services:
 
 volumes:
   neo4j_data: # Named volume for Neo4j data persistence
+
+networks:
+  host:
+    name: host
+    external: true


### PR DESCRIPTION
Local OLLAMA can now be used.

Ref: https://stackoverflow.com/questions/56582446/how-to-use-host-network-for-docker-compose
